### PR TITLE
Fix setup.py to find the namespace package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/AutoActuary/mkdocstrings-vba",
-    packages=setuptools.find_namespace_packages(include=['mkdocstrings_handlers.*']),
+    packages=setuptools.find_namespace_packages(include=["mkdocstrings_handlers.*"]),
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: Other/Proprietary License",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/AutoActuary/mkdocstrings-vba",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_namespace_packages(include=['mkdocstrings_handlers.*']),
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: Other/Proprietary License",


### PR DESCRIPTION
https://github.com/mkdocstrings/mkdocstrings/issues/387

Confirmed it worked by installing the package with `pip install .` in a venv, moving to a completely different directory, and running `from mkdocstrings_handlers import vba` in the venv's Python interpreter.